### PR TITLE
Use Distance struct as return value instead of f64 for Haversine

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let berlin = Location::new(52.518611, 13.408056);
 let moscow = Location::new(55.751667, 37.617778);
 let distance = berlin.haversine_distance_to(&moscow);
 
-println!("Distance = {}", distance);
+println!("Distance = {}", distance.meters());
 ```
 
 * Get the center of a list of coordinates.
@@ -44,7 +44,7 @@ use geoutils::Location;
 
 let berlin = Location::new(52.518611, 13.408056);
 let moscow = Location::new(55.751667, 37.617778);
-let center = Location::center(&[&berlin, &moscow]);
+let center = Location::center(&vec![&berlin, &moscow]);
 
 println!("Center {}, {}", center.latitude(), center.longitude());
 ```

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1,8 +1,15 @@
 use super::Location;
 use std::f64::consts::PI;
+use std::fmt;
 
 /// Distance represents a physical distance in a certain unit.
 pub struct Distance(f64);
+
+impl fmt::Display for Distance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} meters", self.meters())
+    }
+}
 
 impl Distance {
     /// Create a distance in meters.
@@ -172,7 +179,7 @@ pub fn center_of_coords(coords: &[&Location]) -> Location {
 }
 
 /// Implementation of Haversine distance between two points.
-pub fn haversine_distance_to(start: &Location, end: &Location) -> f64 {
+pub fn haversine_distance_to(start: &Location, end: &Location) -> Distance {
     let haversine_fn = |theta: f64| (1.0 - theta.cos()) / 2.0;
 
     let phi1 = start.latitude().to_radians();
@@ -184,5 +191,6 @@ pub fn haversine_distance_to(start: &Location, end: &Location) -> f64 {
     let hav_delta_lambda = phi1.cos() * phi2.cos() * haversine_fn(lambda2 - lambda1);
     let total_delta = hav_delta_phi + hav_delta_lambda;
 
-    (2.0 * 6371e3 * total_delta.sqrt().asin() * 1000.0).round() / 1000.0
+    let dist = (2.0 * 6371e3 * total_delta.sqrt().asin() * 1000.0).round() / 1000.0;
+    Distance::from_meters(dist)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! let moscow = Location::new(55.751667, 37.617778);
 //! let distance = berlin.haversine_distance_to(&moscow);
 //!
-//! println!("Distance = {}", distance);
+//! println!("Distance = {}", distance.meters());
 //! ```
 //!
 //! * Get the center of a list of coordinates.
@@ -39,7 +39,7 @@
 //!
 //! let berlin = Location::new(52.518611, 13.408056);
 //! let moscow = Location::new(55.751667, 37.617778);
-//! let center = Location::center(&[&berlin, &moscow]);
+//! let center = Location::center(&vec![&berlin, &moscow]);
 //!
 //! println!("Center {}, {}", center.latitude(), center.longitude());
 //! ```
@@ -85,6 +85,7 @@ impl Location {
 
     /// Find the distance from itself to another point. Internally uses Vincenty's inverse formula.
     /// For better performance and lesser accuracy, consider [haversine_distance_to](struct.Location.html#method.haversine_distance_to).
+    /// This method returns Err if the formula fails to converge within 100 iterations.
     pub fn distance_to(&self, to: &Location) -> Result<Distance, String> {
         match formula::vincenty_inverse(self, to, 0.00001, 0.0) {
             Ok(res) => Ok(res.distance),
@@ -95,7 +96,7 @@ impl Location {
     /// Find the distance from itself to another point using Haversine formula.
     /// This is usually computationally less intensive than [distance_to](struct.Location.html#method.distance_to) but
     /// is generally not as accurate.
-    pub fn haversine_distance_to(&self, to: &Location) -> f64 {
+    pub fn haversine_distance_to(&self, to: &Location) -> Distance {
         formula::haversine_distance_to(self, to)
     }
 
@@ -136,7 +137,7 @@ mod tests {
         let l2 = Location::new(27.740286, 85.337059);
 
         let distance = l1.haversine_distance_to(&l2);
-        assert_eq!(distance, 56.36);
+        assert_eq!(distance.meters(), 56.36);
     }
 
     #[test]


### PR DESCRIPTION
This should've been the case in 0.3.0 but I missed it.