### PR TITLE
Add normal derives to the distance struct

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -3,6 +3,7 @@ use std::f64::consts::PI;
 use std::fmt;
 
 /// Distance represents a physical distance in a certain unit.
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Distance(f64);
 
 impl fmt::Display for Distance {


### PR DESCRIPTION
Same derives that are on Location (not having copy is sorely missed)