### PR TITLE
Add Optional Serde Derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,8 @@ authors = ["Srishan Bhattarai <srishanbhattarai@gmail.com>"]
 [badges]
 travis-ci = { repository = "srishanbhattarai/geoutils" }
 
-
 [dependencies]
+serde = { version = "1", optional = true, features = ["derive"] }
+
+[features]
+default = []

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -2,8 +2,12 @@ use super::Location;
 use std::f64::consts::PI;
 use std::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Distance represents a physical distance in a certain unit.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Distance(f64);
 
 impl fmt::Display for Distance {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,14 @@
 #![deny(missing_docs)]
 mod formula;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub use formula::Distance;
 
 /// Location defines a point using it's latitude and longitude.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Location(f64, f64);
 
 impl Location {


### PR DESCRIPTION
# Overview

Adds serde as an optional dependency, and a non-default feature which allows deriving the `Serialization` and `Deserialization` on the `Location` and `Distance` types.