### PR TITLE
rkyv support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ travis-ci = { repository = "srishanbhattarai/geoutils" }
 
 [dependencies]
 serde = { version = "1", optional = true, features = ["derive"] }
+rkyv = { version = "0.8", optional = true }
 
 [features]
 default = []

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -7,7 +7,8 @@ use std::fmt;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    rkyv(compare(PartialEq), derive(Debug))
 )]
 pub struct Distance(f64);
 

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -5,6 +5,10 @@ use std::fmt;
 /// Distance represents a physical distance in a certain unit.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct Distance(f64);
 
 impl fmt::Display for Distance {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,10 @@ pub use formula::Distance;
 /// Location defines a point using its latitude and longitude.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct Location(f64, f64);
 
 impl Location {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 #![deny(missing_docs)]
 mod formula;
 
+#[cfg(feature = "rkyv")]
+pub use formula::ArchivedDistance;
 pub use formula::Distance;
 
 /// Location defines a point using its latitude and longitude.
@@ -60,7 +62,8 @@ pub use formula::Distance;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    rkyv(compare(PartialEq), derive(Debug))
 )]
 pub struct Location(f64, f64);
 
@@ -159,5 +162,53 @@ mod tests {
         let jakarta = Location::new(-6.125556, 106.655833);
 
         assert_eq!(JAKARTA, jakarta)
+    }
+
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn test_rkyv_location() {
+        let location = Location::new(-6.125556, 106.655833);
+
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&location).unwrap();
+
+        assert_eq!(
+            rkyv::from_bytes::<Location, rkyv::rancor::Error>(&bytes).unwrap(),
+            location,
+        );
+
+        let archived_location =
+            rkyv::access::<ArchivedLocation, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(archived_location, &location);
+        assert_eq!(&location, archived_location);
+
+        // SAFETY: We generated these bytes in this test and also just
+        // accessed them in a checked way
+        let archived_location = unsafe { rkyv::access_unchecked::<ArchivedLocation>(&bytes) };
+        assert_eq!(archived_location, &location);
+        assert_eq!(&location, archived_location);
+    }
+
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn test_rkyv_distance() {
+        let distance = Distance::from_meters(2000.0);
+
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&distance).unwrap();
+
+        assert_eq!(
+            rkyv::from_bytes::<Distance, rkyv::rancor::Error>(&bytes).unwrap(),
+            distance,
+        );
+
+        let archived_distance =
+            rkyv::access::<ArchivedDistance, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(archived_distance, &distance);
+        assert_eq!(&distance, archived_distance);
+
+        // SAFETY: We generated these bytes in this test and also just
+        // accessed them in a checked way
+        let archived_distance = unsafe { rkyv::access_unchecked::<ArchivedDistance>(&bytes) };
+        assert_eq!(archived_distance, &distance);
+        assert_eq!(&distance, archived_distance);
     }
 }


### PR DESCRIPTION
Hi,
I ended up wanting [`rkyv`](https://rkyv.org) support for `geoutils` in a project I'm working on, so I forked `geoutils` and added in `rkyv` support behind a new `rkyv` feature

So I figured I'd go ahead and open a PR here if you would like to include that feature in the official `geoutils` crate?

For some context, it seems `rkyv` has gotten relatively popular eg the well-known `chrono` crate has features to include `rkyv` support

As far as I'm aware there are two alternatives (if one wants to use `geoutils` + `rkyv` so to speak) to adding an `rkyv` feature here:
1. `rkyv` supports ["remote derive"](https://rkyv.org/derive-macro-features/remote-derive.html) for doing third-party wrapping of types
2. `rkyv` bakes in support for some popular Rust libraries eg `smol_str` behind its own feature flags